### PR TITLE
Added tools for large scale merging operation

### DIFF
--- a/nuclei_prediction/format_nuc_merge.py
+++ b/nuclei_prediction/format_nuc_merge.py
@@ -1,0 +1,32 @@
+from taskqueue import LocalTaskQueue
+import sys
+import os
+import pandas as pd
+sys.path.append(os.path.abspath("../segmentation"))
+from merge_operation import create_nuc_merge_tasks
+import numpy as np
+
+parallel_cpu = 1 # 12 for htem
+merge_file = "/Users/sumiya/git/FANC_auto_recon/Output/proofread_soma_temp.csv"
+seg_source = 'graphene://https://cave.fanc-fly.com/segmentation/table/mar2021_prod'
+
+# read csv file and select pairs within the same cells
+df = pd.read_csv(merge_file, header=0)
+df = df[(df.is_neuron=='y') & (df.is_inside=='y')]
+
+df_to_merge = df.reindex(columns=['nuc_svID','soma_svID', 'nuc_xyz', 'soma_xyz'])
+df_to_merge.columns =['nuc_sv_id', 'cell_sv_id', 'nuc_sv_id_loc', 'cell_sv_id_loc']
+nuc_xyz_df = df['nuc_xyz'].str.strip('()').str.split(',',expand=True)
+soma_xyz_df = df['soma_xyz'].str.strip('()').str.split(',',expand=True)
+df_to_merge['nuc_sv_id_loc'] = nuc_xyz_df.astype(int).values.tolist()
+df_to_merge['cell_sv_id_loc'] = soma_xyz_df.astype(int).values.tolist()
+df_to_merge.reset_index(drop=True, inplace=True)
+
+# merge
+tq = LocalTaskQueue(parallel=parallel_cpu)
+tq.insert(create_nuc_merge_tasks(df_to_merge,
+                                         seg_source,
+                                         'file:///Users/sumiya/git/FANC_auto_recon/Output/log_merge', # path in cloudfiles  format
+                                         resolution=(4.3,4.3,45)))
+tq.execute(progress=True)
+print('Done')

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,5 @@ argparse
 task-queue
 glob2
 caveclient
+cloud-files
+urllib3

--- a/segmentation/merge_operation.py
+++ b/segmentation/merge_operation.py
@@ -8,6 +8,11 @@ from taskqueue import RegisteredTask
 
 
 class PerformMergeTask(RegisteredTask):
+    """
+    CAUTION: Large scale merging operation massively affects materialization of CAVE tables. 
+             Contact Cave team before running this code.
+    This code is adapted from Forrest Collman's work.
+    """
 
     def __init__(
         self,

--- a/segmentation/merge_operation.py
+++ b/segmentation/merge_operation.py
@@ -1,0 +1,131 @@
+import time
+import copy
+import numpy as np
+from urllib.error import HTTPError
+from caveclient import CAVEclient
+from cloudfiles import CloudFiles
+from taskqueue import RegisteredTask
+
+
+class PerformMergeTask(RegisteredTask):
+
+    def __init__(
+        self,
+        pcg_source="",
+        bucket_save_location="",
+        A_sv_id=0,
+        B_sv_id=0,
+        A_sv_id_loc=(0, 0, 0),
+        B_sv_id_loc=(0, 0, 0),
+        resolution=(4.3, 4.3, 45),
+        datastack_name="fanc_production_mar2021",
+    ):
+        """[summary]
+
+        Args:
+            pcg_source (str, optional): [description]. Defaults to "".
+            bucket_save_location (str, optional): [description]. Defaults to "".
+            A_sv_id (int, optional): [description]. Defaults to 0.
+            B_sv_id (int, optional): [description]. Defaults to 0.
+            A_sv_id_loc (tuple, optional): [description]. Defaults to (0,0,0).
+            B_sv_id_loc (tuple, optional): [description]. Defaults to (0,0,0).
+            resolution (tuple, optional): [description]. Defaults to (4.3,4.3,45).
+            datastack_name (str, optional): [description]. Defaults to "fanc_production_mar2021".
+        """
+        super().__init__(
+            pcg_source,
+            bucket_save_location,
+            A_sv_id,
+            B_sv_id,
+            A_sv_id_loc,
+            B_sv_id_loc,
+            resolution,
+            datastack_name,
+        )
+
+        self.pcg_source = pcg_source
+        self.bucket_save_location = bucket_save_location
+        self.A_sv_id = A_sv_id
+        self.B_sv_id = B_sv_id
+        self.A_sv_id_loc = A_sv_id_loc
+        self.B_sv_id_loc = B_sv_id_loc
+        self.resolution = resolution
+        self.datastack_name = datastack_name
+
+    def execute(self):
+        client = CAVEclient(self.datastack_name)
+        roots = client.chunkedgraph.get_roots([self.A_sv_id, self.B_sv_id])
+        r = {}
+
+        if roots[0] != roots[1]:
+            try:
+                client.chunkedgraph.do_merge(
+                    [self.A_sv_id, self.B_sv_id],
+                    [np.array(self.A_sv_id_loc), np.array(self.B_sv_id_loc)],
+                    resolution=self.resolution
+                )
+                r["did_merge"] = True
+            except (Exception, HTTPError) as e:
+                r = {}
+                t = 10
+                print("timeout error.. ")
+                for i in range(t):
+                    print("sleeping..")
+                    time.sleep(30)
+                    root_test = client.chunkedgraph.get_roots(
+                        [self.A_sv_id, self.B_sv_id]
+                    )
+                    if root_test[0] == root_test[1]:
+
+                        print("merge test found completion")
+                        r["did_merge"] = True
+                        r["new_root_id"] = root_test[1]
+                        break
+                if "did_merge" not in r.keys():
+                    r["did_merge"] = "Merge appeared to have failed after {} minutes of waiting. {}".format(0.5*t, e)
+        
+        else:
+            r["did_merge"] = False
+
+        r["A_sv_id"] = self.A_sv_id
+        r["B_sv_id"] = self.B_sv_id
+        r["A_sv_id_loc"] = self.A_sv_id_loc
+        r["B_sv_id_loc"] = self.B_sv_id_loc
+        r["A_root"] = roots[0]
+        r["B_root"] = roots[1]
+        cf = CloudFiles(self.bucket_save_location)
+        cf.put_json(f"{self.B_sv_id}.json", r)
+        print(r)
+        return
+
+
+def create_nuc_merge_tasks(df, pcg_source, bucket_save_location, resolution=(4.3, 4.3, 45)):
+    class PerformNucMergeTaskIterator(object):
+        def __init__(self, df, pcg_source, bucket_save_location, resolution=(4.3, 4.3, 45)):
+            self.pcg_source = pcg_source
+            self.bucket_save_location = bucket_save_location
+            self.df = df
+            self.resolution = resolution
+
+        def __len__(self):
+            return len(self.df)
+
+        def __getitem__(self, slc):
+            itr = copy.deepcopy(self)
+            itr.df = df.iloc[slc]
+            return itr
+
+        def __iter__(self):
+
+            for num, row in self.df.iterrows():
+                yield PerformMergeTask(
+                    self.pcg_source,
+                    self.bucket_save_location,
+                    row.nuc_sv_id,
+                    row.cell_sv_id,
+                    row.nuc_sv_id_loc,
+                    row.cell_sv_id_loc,
+                    self.resolution,
+                )
+
+    return PerformNucMergeTaskIterator(df, pcg_source, bucket_save_location, resolution)


### PR DESCRIPTION
I added codes to programmatically merge pairs of segmentations. **This code massively affects the materialization of CAVE tables. Contact the CAVE team before running this code.**

- `merge_operation.py` has `PerformMergeTask` that can automatically merge pairs of supervoxels/coordinates using the ChunkedGraph client. The operation output for each pair will be stored as JSON files. It also has `create_nuc_merge_tasks`, which helps users to merge pairs in a dataframe.
- `format_nuc_merge.py` shows how I used this code in Jan 2022 to merge 14579 nuclei and somas. I manually checked the coordinates of every single nucleus/soma pair before this operation. 8051 pairs turned out to be separated and 8049 of them were successfully merged. Only 2 of them result in errors.

Let me know if you have any questions.