### PR TITLE
Add nuclei layer when previewing soma table

### DIFF
--- a/fanc/upload.py
+++ b/fanc/upload.py
@@ -256,7 +256,7 @@ class SomaTableOrganizer(object):
         else:
             raise ValueError("Either asPoint or asSphere should be True")
 
-        print(render_scene(annotations=annotations, client=self._client))
+        print(render_scene(annotations=annotations, nuclei=st.id.values, client=self._client))
 
     def add_dataframe(self, df: pd.DataFrame, bath_size=10000):
         """


### PR DESCRIPTION
Following up on a recent commit 1ab6f2a9973b668ea211fd530c6bd495919328f5 that added a feature to show valid nuclei to `render_scene()`, `SomaTableOrganizer.preview()` now also shows valid nuclei in the soma table.