### PR TITLE
Use query service hosted at hms.

### DIFF
--- a/fanc/lookup.py
+++ b/fanc/lookup.py
@@ -23,7 +23,7 @@ default_annotation_sources = [('neuron_information', 'tag'),
                               ('neck_connective', 'tag'),
                               ('peripheral_nerves', 'tag')]
 default_anchor_point_sources = ['cell_ids_v2', 'somas_dec2022', 'peripheral_nerves', 'neck_connective']
-default_svid_lookup_url = 'https://services.itanna.io/app/transform-service/query/dataset/fanc_v4/s/2/values_array_string_response/'
+default_svid_lookup_url = 'https://catmaid3.hms.harvard.edu/services/transform-service/query/dataset/fanc_v4/s/2/values_array_string_response'
 
 
 # --- START CAVE TABLES / ANNOTATIONS SECTION --- #

--- a/fanc/transforms/realignment.py
+++ b/fanc/transforms/realignment.py
@@ -27,7 +27,7 @@ def fanc4_to_3(*pts, subpixel_interpolation=False, scale=2, return_dict=False):
         Returned coordinates are floats (i.e. can have fractional values)
     """
              
-    base = 'https://spine.itanna.io/app/transform-service/dataset/fanc_v4_to_v3/s/{}/'.format(scale)
+    base = 'https://catmaid3.hms.harvard.edu/services/transform-service/dataset/fanc_v4_to_v3/s/{}/'.format(scale)
 
     if len(pts) == 1:
         pts = pts[0]


### PR DESCRIPTION
A small change to use the HMS hosted transform service for `fanc_v4` and `fanc_v4_to_v3`.

Tested by tweaking `tests/tests.py` to call `test_lookup()`.