### PR TITLE
Migrate fanc.statebuilder to nglui v4 API

### DIFF
--- a/fanc/statebuilder.py
+++ b/fanc/statebuilder.py
@@ -15,9 +15,7 @@ except ImportError:
 import pymaid
 from cloudvolume import CloudVolume
 from cloudvolume.frontends.precomputed import CloudVolumePrecomputed
-from nglui.statebuilder import (StateBuilder, ChainedStateBuilder,
-                                ImageLayerConfig, SegmentationLayerConfig,
-                                AnnotationLayerConfig, PointMapper, SphereMapper)
+from nglui.statebuilder import ViewerState
 
 from . import auth, catmaid, lookup
 from .transforms import realignment
@@ -301,33 +299,33 @@ def render_scene(neurons=None,
             kwargs['bg_color'] == '#ffffff'
         misc_settings['perspectiveViewBackgroundColor'] = kwargs['bg_color']
 
-    # Make layers
-    img_config = ImageLayerConfig(
-        name=ngl_info.im['name'],
-        source=ngl_info.im['path']
-    )
-    seg_config = SegmentationLayerConfig(
-        name=ngl_info.seg['name'],
-        source=ngl_info.seg['path'],
-        selected_ids_column='pt_root_id',
-        color_column=color_column,
-        fixed_ids=None,
-        active=True
+    # Build the viewer state (nglui v4 API)
+    vs = ViewerState(
+        dimensions=list(ngl_info.voxel_size),
+        position=ngl_info.view_options.get('position'),
+        scale_3d=ngl_info.view_options.get('zoom_3d', 50000.0),
+        layout=ngl_info.view_options.get('layout', 'xy-3d'),
     )
 
-    def StateBuilderDefaultSettings(layers):
-        return StateBuilder(
-            layers=layers,
-            resolution=ngl_info.voxel_size,
-            view_kws=ngl_info.view_options
+    vs.add_image_layer(source=ngl_info.im['path'], name=ngl_info.im['name'])
+    vs.add_segmentation_layer(source=ngl_info.seg['path'], name=ngl_info.seg['name'])
+    if color_column:
+        vs.add_segments_from_data(
+            data=neurons,
+            segment_column='pt_root_id',
+            color_column=color_column,
+            name=ngl_info.seg['name'],
         )
+    else:
+        segments = neurons['pt_root_id'].dropna().tolist()
+        if segments:
+            vs.add_segments(segments=segments, name=ngl_info.seg['name'])
+    vs.set_viewer_properties(selected_layer=ngl_info.seg['name'])
 
-    # Additional layer(s)
-    additional_states = []
-    additional_data = []
+    # Annotation layer(s)
     if annotations is not None:
         if annotation_units in ['nm', 'nanometer', 'nanometers']:
-            annotation_layer_resolution = (1, 1, 1)
+            annotation_layer_resolution = [1, 1, 1]
         else:
             annotation_layer_resolution = None
 
@@ -358,64 +356,53 @@ def render_scene(neurons=None,
             elif isinstance(i['data'], pd.Series):
                 data = i['data'].to_frame(name='pt_position')
             elif isinstance(i['data'], pd.DataFrame):
-                data = i['data']
+                data = i['data'].copy()
             else:
                 raise TypeError('Could not convert annotation data to DataFrame')
 
-            if 'pt_root_id' in data.columns:
-                segid_column = 'pt_root_id'
-            else:
-                segid_column = None
+            segid_column = 'pt_root_id' if 'pt_root_id' in data.columns else None
 
             if i['type'] == 'points':
-                anno_mapper = PointMapper(point_column='pt_position',
-                                          linked_segmentation_column=segid_column)
+                vs.add_points(
+                    data=data,
+                    name=i['name'],
+                    point_column='pt_position',
+                    segment_column=segid_column,
+                    data_resolution=annotation_layer_resolution,
+                )
             elif i['type'] == 'spheres':
-                anno_mapper = SphereMapper(center_column='pt_position',
-                                           radius_column='radius_nm',
-                                           linked_segmentation_column=segid_column)
+                # nglui v4 ellipsoids take a 3-vector of radii per row;
+                # expand the scalar radius_nm column into (r, r, r).
+                data['radii_nm'] = data['radius_nm'].apply(lambda r: [r, r, r])
+                vs.add_ellipsoids(
+                    data=data,
+                    name=i['name'],
+                    center_column='pt_position',
+                    radii_column='radii_nm',
+                    segment_column=segid_column,
+                    data_resolution=annotation_layer_resolution,
+                )
             else:
                 raise NotImplementedError(f"Unrecognized annotation type: '{i['type']}'")
 
-            anno_layer = AnnotationLayerConfig(
-                name=i['name'],
-                mapping_rules=anno_mapper,
-                data_resolution=annotation_layer_resolution
-            )
-            additional_states.append(
-                StateBuilderDefaultSettings([anno_layer])
-            )
-            additional_data.append(data)
     if nuclei_layer:
-        nuclei_config = SegmentationLayerConfig(name=ngl_info.nuclei['name'],
-                                                source=ngl_info.nuclei['path'],
-                                                selected_ids_column='nucleus_id')
+        vs.add_segmentation_layer(
+            source=ngl_info.nuclei['path'],
+            name=ngl_info.nuclei['name'],
+        )
         if 'nuclei' in kwargs:
             try:
                 iter(kwargs['nuclei'])
-                nucleus_ids = kwargs['nuclei']
-            except:
+                nucleus_ids = list(kwargs['nuclei'])
+            except TypeError:
                 nucleus_ids = [kwargs['nuclei']]
-            nuclei_df = pd.DataFrame(columns=['nucleus_id'])
-            nuclei_df['nucleus_id'] = nucleus_ids
-            additional_data.append(nuclei_df)
-        else:
-            additional_data.append(None)
-        additional_states.append(StateBuilderDefaultSettings([nuclei_config]))
+            if nucleus_ids:
+                vs.add_segments(segments=nucleus_ids, name=ngl_info.nuclei['name'])
+
     if synapses_layer:
-        synapses_config = ImageLayerConfig(name=ngl_info.syn['name'],
-                                           source=ngl_info.syn['path'])
-        additional_states.append(StateBuilder([synapses_config]))
-        additional_data.append(None)
+        vs.add_image_layer(source=ngl_info.syn['path'], name=ngl_info.syn['name'])
 
-    # Build a state with the requested layers
-    standard_state = StateBuilderDefaultSettings([img_config, seg_config])
-    chained_sb = ChainedStateBuilder([standard_state] + additional_states)
-
-    # Turn state into a dict, then add some last settings manually
-    state = chained_sb.render_state([neurons] + additional_data,
-                                    return_as='dict',
-                                    target_site='cave-explorer')
+    state = vs.to_dict()
     if outlines_layer:
         state['layers'].insert(2, ngl_info.outlines_layer)
     ngl_info.final_json_tweaks(state)
@@ -427,6 +414,6 @@ def render_scene(neurons=None,
         json_id = client.state.upload_state_json(state)
         return client.state.build_neuroglancer_url(json_id,
                                                    ngl_info.ngl_app_url,
-                                                   'cave-explorer')
+                                                   'spelunker')
     else:
         raise ValueError('"return_as" must be "json" or "url" but was {}'.format(return_as))

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ meshparty
 navis
 flybrains
 transformix
-nglui
+nglui>=4.0.0
 pyperclip
 numpyimage
 pandas

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open('requirements.txt', 'r') as f:
 
 setuptools.setup(
     name='fanc-fly',
-    version='3.2.1',
+    version='3.2.2',
     author='Jasper Phelps',
     author_email='jasper.s.phelps@gmail.com',
     description='Tools for the Female Adult Nerve Cord Drosophila EM dataset',


### PR DESCRIPTION
## Summary
Closes #36.

nglui 4.0 introduces a breaking API: `StateBuilder` / `ChainedStateBuilder` / the per-layer config classes (`ImageLayerConfig`, `SegmentationLayerConfig`, `AnnotationLayerConfig`) / `PointMapper` / `SphereMapper` were all removed in favor of a single `ViewerState` object with `add_*` methods, and only the spelunker viewer is supported (no more `cave-explorer`).

This PR migrates `fanc.statebuilder.render_scene` to the v4 API. The public signature is unchanged, so existing callers in `fanc.upload`, `fanc.lookup`, and `slackbots.annotation_bot` keep working without modification.

- Replace the StateBuilder + layer-config + ChainedStateBuilder pipeline with a single `ViewerState`, using `add_image_layer`, `add_segmentation_layer`, `add_segments` / `add_segments_from_data`, `add_points`, and `add_ellipsoids`.
- For `'spheres'` annotations, expand the scalar `radius_nm` column into a `[r, r, r]` `radii_nm` column to match `add_ellipsoids`' per-axis-radii input shape.
- Switch the site arg in `client.state.build_neuroglancer_url(...)` from `'cave-explorer'` to `'spelunker'`.
- Pin `nglui>=4.0.0` in `requirements.txt`.

## Test plan
End-to-end exercised in a fresh Python 3.13 venv with the full updated `requirements.txt` installed, against the live `fanc_production_mar2021` CAVE backend:

- [x] `render_scene(neurons=[648518346481082458], return_as='json')` → returns dict with layers `['FANCv4', 'segmentation proofreading', 'region outlines']`.
- [x] `render_scene(neurons=[648518346481082458], annotations=np.array([[48848, 114737, 2690], [50000, 100000, 2700]]), return_as='url')` → uploads through the CAVE state shortener and returns a real spelunker URL (verified opens correctly in the browser).
- [x] Standalone replays of the layer-construction logic confirm:
  - bare-segments path (`add_segments`),
  - colored-DataFrame path (`add_segments_from_data` produces `segmentColors`),
  - point annotations in voxel and nm units,
  - sphere annotations → ellipsoid annotations (3-vector radii),
  - `nuclei_layer=True` (with and without explicit IDs),
  - `synapses_layer=True`.
- [x] Reviewer to spot-check a generated URL renders correctly in spelunker.