### PR TITLE
Clean up unused imports; make vtk an optional [all] extra

### DIFF
--- a/fanc/connectivity.py
+++ b/fanc/connectivity.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-import json
-import re
 import warnings
 import sqlite3
 

--- a/fanc/statebuilder.py
+++ b/fanc/statebuilder.py
@@ -1,20 +1,9 @@
 #!/usr/bin/env python3
 
-import os
-import json
-
 import numpy as np
 import pandas as pd
 from matplotlib import cm, colors
-import vtk
-from meshparty import trimesh_vtk, trimesh_io, meshwork
-try:
-    from trimesh import exchange
-except ImportError:
-    from trimesh import io as exchange
 import pymaid
-from cloudvolume import CloudVolume
-from cloudvolume.frontends.precomputed import CloudVolumePrecomputed
 from nglui.statebuilder import ViewerState
 
 from . import auth, catmaid, lookup
@@ -136,7 +125,6 @@ def fragment_dataframes(seg_ids, coords,
     neuron_df.pt_root_id = ids_to_use
 
     for i in range(len(ids_to_use)):
-        idx = seg_ids == ids_to_use[i]
         neuron_df.loc[neuron_df.pt_root_id == ids_to_use[i], 'color'] = sk_colors[i]
 
     neuron_df = neuron_df.append({'pt_root_id': primary_neuron[0], 'pt_position': None, 'color': "#ff0000"}, ignore_index=True)

--- a/fanc/statemanager.py
+++ b/fanc/statemanager.py
@@ -2,7 +2,6 @@
 
 import os
 from pathlib import Path
-import json
 
 import pandas as pd
  

--- a/fanc/synaptic_links.py
+++ b/fanc/synaptic_links.py
@@ -1,12 +1,7 @@
 #!/usr/bin/env python3
 
-import os
-from pathlib import Path
 import json
-import csv
 from secrets import token_hex
-import random
-import sqlite3
 
 import numpy as np
 import pandas as pd

--- a/fanc/transforms/realignment.py
+++ b/fanc/transforms/realignment.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python3
 
-import os
-
 import numpy as np
 import requests
-import tqdm
 
 
 def fanc4_to_3(*pts, subpixel_interpolation=False, scale=2, return_dict=False):
@@ -110,7 +107,6 @@ def fanc3_to_4(*pts, mode='descent', precision=1, verbose=False):
     if len(pts) == 1:
         pts = pts[0]
     pts = np.array(pts, dtype=np.float64)
-    ndims = len(pts.shape)
 
     if mode == 'descent':
         # Use this mode if the v3 to v4 alignment

--- a/fanc/transforms/template_alignment.py
+++ b/fanc/transforms/template_alignment.py
@@ -56,7 +56,7 @@ def align_mesh(mesh: Union[int, object],
       If True, print additional information during processing.
     """
     import navis
-    import flybrains
+    import flybrains  # noqa: F401  registers the FANC/template brain spaces with navis
     if np.issubdtype(type(mesh), np.integer):
         seg_id = mesh
         inplace = False
@@ -169,8 +169,6 @@ def warp_points_FANC_to_template(points,
       https://github.com/htem/GridTape_VNC_paper/tree/main/template_registration_pipeline/register_EM_dataset_to_template
     This function is a slight improvement on the published version.
     """
-    import navis
-    import flybrains
     # Only required for deprecated functions so not imported up top
     import transformix  # https://github.com/jasper-tms/pytransformix
 

--- a/fanc/upload.py
+++ b/fanc/upload.py
@@ -12,7 +12,6 @@ import time
 import numpy as np
 import pandas as pd
 from requests.exceptions import HTTPError
-from caveclient import CAVEclient
 from caveclient.chunkedgraph import root_id_int_list_check
 from cloudvolume import CloudVolume
 from cloudvolume.lib import green, red

--- a/fanc/visualize.py
+++ b/fanc/visualize.py
@@ -4,12 +4,6 @@ import os
 
 import numpy as np
 from matplotlib import cm
-import vtk
-from meshparty import trimesh_vtk, trimesh_io, meshwork
-try:
-    from trimesh import exchange
-except ImportError:
-    from trimesh import io as exchange
 
 from . import auth, connectivity
 from .transforms import template_alignment
@@ -86,6 +80,8 @@ def plot_neurons(segment_ids,
         output png image
         (generate two images with/without scale bar if you specify to plot it)
     """
+
+    from meshparty import trimesh_vtk, trimesh_io, meshwork
 
     if isinstance(segment_ids, (int, np.integer)):
         segment_ids = [segment_ids]
@@ -241,6 +237,8 @@ def scale_bar_actor_2D(center, camera, view='X', length=10000, color=(0, 0, 0), 
     Creates a scale bar actor very similar to trimesh_vtk.scale_bar_actor(), but on a specific plane with
     a given size.
     """
+    import vtk
+
     axes_actor = vtk.vtkCubeAxesActor2D()
     axes_actor.SetBounds(center[0], center[0]+length,
                          center[1], center[1]+length,
@@ -284,6 +282,11 @@ def scale_bar_actor_2D(center, camera, view='X', length=10000, color=(0, 0, 0), 
 
 
 def read_mesh_stl(filename):
+    try:
+        from trimesh import exchange
+    except ImportError:
+        from trimesh import io as exchange
+
     with open(filename, 'r') as fp:
         mesh_d = exchange.stl.load_stl(fp)
     vertices = mesh_d['vertices']

--- a/fanc/visualize.py
+++ b/fanc/visualize.py
@@ -3,10 +3,9 @@
 import os
 
 import numpy as np
-from matplotlib import cm, colors
+from matplotlib import cm
 import vtk
 from meshparty import trimesh_vtk, trimesh_io, meshwork
-from cloudvolume.frontends.precomputed import CloudVolumePrecomputed
 try:
     from trimesh import exchange
 except ImportError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fanc-fly"
-version = "3.2.2"
+version = "3.2.3"
 description = "Tools for the Female Adult Nerve Cord Drosophila EM dataset"
 readme.file = "README.md"
 readme.content-type = "text/markdown"
@@ -43,6 +43,9 @@ dependencies = [
     "pcg_skel",
     "anytree",
 ]
+
+[project.optional-dependencies]
+all = ["vtk"]
 
 [project.urls]
 Homepage = "https://github.com/htem/FANC_auto_recon"


### PR DESCRIPTION
## Summary

Three commits, each independently reviewable:

1. **`dd9846a2` — Remove unused imports and locals (flake8 F401/F841).** A `flake8 -F` sweep across the package, excluding `__init__.py`s where the F401 hits are intentional namespace re-exports. No behavioral change. Drops 21 dead `import` lines and 2 unused locals across 8 files.

2. **`e87cdf83` — visualize.py: lazy-import vtk and meshparty.trimesh_vtk.** `fanc/visualize.py` is the only place that legitimately uses vtk and meshparty's vtk-using submodules. Previously these were imported at module top, so any \`import fanc\` (which re-exports `plot_neurons` via `__init__.py`) transitively forced vtk to be installed for users who never call any plotting code. Move all four — `vtk`, `meshparty.{trimesh_vtk, trimesh_io, meshwork}`, and the `trimesh.exchange` try/except — into the bodies of the three functions that actually use them.

3. **`ac8ce90b` — Make vtk an optional `[all]` extra; bump 3.2.2 → 3.2.3.** vtk moves from a required dep (it was only ever pulled in transitively, via meshparty's `[viz]` extra never being declared in our pyproject — hence the install bug you hit on a fresh env) to `[project.optional-dependencies] all = ["vtk"]`. Users who want plotting now install via `pip install fanc-fly[all]`.

## Why

You hit this in a fresh env: \`import fanc\` failed because vtk wasn't installed, even though vtk wasn't in the dependencies list. Two compounding causes:
- `statebuilder.py` had a top-level `import vtk` that was completely dead (never referenced anywhere in the file).
- `visualize.py` legitimately uses vtk, but importing visualize (via `__init__.py`'s `from .visualize import plot_neurons`) eagerly pulled vtk in for everyone.

After this PR, vtk is needed only by code that actually uses it, and explicitly so via the `[all]` extra.

## What's NOT in this PR (deliberately)

- The F722/F821 errors in `fanc/upload.py:24-25` (abuse of type-annotation syntax with bare names like `'soma'` and `'peripheral nerve'` to document allowed values). Should probably become `Literal[...]` from `typing`, but that's a substantive code change, not a flake8 sweep.
- The F821 \`needtogetfile\` placeholder in `visualize.py:190-195`. That's a never-finished branch in `plot_neurons`; needs an actual fix.
- The F401 hits in `__init__.py` files. Those are intentional namespace re-exports (`from .auth import *` etc.); silencing them with `# noqa` or `__all__` is bikeshed-y.

## Test plan

- [x] `flake8 fanc/ --select=F401,F811,F841 --exclude=__init__.py` is silent after this PR.
- [x] `import fanc` in the `fanc` venv (with vtk installed) still succeeds; `fanc.statebuilder.render_scene(...)` still produces the expected 3-layer neuroglancer state.
- [x] After lazy-import, `import fanc` no longer pulls vtk into `sys.modules` (verified: `'vtk' not in sys.modules` after `import fanc`).
- [x] `python -m build --wheel` against the new pyproject succeeds; wheel METADATA shows `Provides-Extra: all` and `Requires-Dist: vtk; extra == "all"`, with vtk no longer in the base `Requires-Dist` block.
- [ ] Reviewer to confirm `pip install fanc-fly==3.2.3` (without `[all]`) works in a fresh env without vtk, and `pip install fanc-fly[all]==3.2.3` pulls vtk in. Both will need the workflow to actually publish first.

## After merge

The trusted-publisher workflow on `main` will trigger on this PR's merge (since `pyproject.toml` is touched) and publish 3.2.3 to PyPI + cut a `v3.2.3` GitHub Release — assuming the PyPI Trusted Publisher is configured (https://pypi.org/manage/project/fanc-fly/settings/publishing/). If it isn't yet, the workflow will fail loudly on the publish step and you can configure + re-run.